### PR TITLE
Add Metabase samples and configure Airflow DB connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+airflow-pipeline/logs/
+*.log
+.env

--- a/airflow-pipeline/dags/cdc_to_star.py
+++ b/airflow-pipeline/dags/cdc_to_star.py
@@ -1,0 +1,90 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from datetime import datetime
+import json
+import os
+import psycopg2
+
+def etl_cdc_to_star():
+    oltp = psycopg2.connect(
+        host=os.environ.get('OLTP_HOST', 'oltp-db'),
+        database=os.environ.get('OLTP_DB', 'coffee_oltp'),
+        user=os.environ.get('OLTP_USER', 'brew'),
+        password=os.environ.get('OLTP_PASSWORD', 'brew'),
+    )
+    olap = psycopg2.connect(
+        host=os.environ.get('OLAP_HOST', 'olap-db'),
+        database=os.environ.get('OLAP_DB', 'coffee_olap'),
+        user=os.environ.get('OLAP_USER', 'brew'),
+        password=os.environ.get('OLAP_PASSWORD', 'brew'),
+    )
+    oltp.autocommit = True
+    olap.autocommit = True
+
+    src = oltp.cursor()
+    dst = olap.cursor()
+    src.execute("SELECT id, payload FROM cdc_orders WHERE processed=false ORDER BY id")
+    rows = src.fetchall()
+    for row_id, payload in rows:
+        order = payload
+        # dimensions
+        dst.execute(
+            "INSERT INTO dim_customer (customer_id) VALUES (%s) ON CONFLICT (customer_id) DO NOTHING",
+            (order['customer_id'],),
+        )
+        dst.execute(
+            "INSERT INTO dim_product (product_id, price) VALUES (%s, %s) ON CONFLICT (product_id) DO NOTHING",
+            (order['product_id'], order['price']),
+        )
+        dst.execute(
+            "INSERT INTO dim_employee (employee_id) VALUES (%s) ON CONFLICT (employee_id) DO NOTHING",
+            (order['employee_id'],),
+        )
+        dst.execute(
+            "INSERT INTO dim_date (date) VALUES (%s::date) ON CONFLICT (date) DO NOTHING",
+            (order['order_time'],),
+        )
+        dst.execute("SELECT id FROM dim_customer WHERE customer_id=%s", (order['customer_id'],))
+        customer_dim = dst.fetchone()[0]
+        dst.execute("SELECT id FROM dim_product WHERE product_id=%s", (order['product_id'],))
+        product_dim = dst.fetchone()[0]
+        dst.execute("SELECT id FROM dim_employee WHERE employee_id=%s", (order['employee_id'],))
+        employee_dim = dst.fetchone()[0]
+        dst.execute("SELECT id FROM dim_date WHERE date=%s::date", (order['order_time'],))
+        date_dim = dst.fetchone()[0]
+        dst.execute(
+            """
+            INSERT INTO fact_sales(date_id, customer_dim_id, product_dim_id, employee_dim_id, quantity, price, total, order_time)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            (
+                date_dim,
+                customer_dim,
+                product_dim,
+                employee_dim,
+                order['quantity'],
+                order['price'],
+                order['quantity'] * order['price'],
+                order['order_time'],
+            ),
+        )
+        src.execute("UPDATE cdc_orders SET processed=true WHERE id=%s", (row_id,))
+    src.close()
+    dst.close()
+    oltp.close()
+    olap.close()
+
+default_args = {
+    'owner': 'brewlytics',
+    'start_date': datetime(2023, 1, 1),
+}
+
+with DAG(
+    'cdc_to_star',
+    default_args=default_args,
+    schedule_interval='*/5 * * * *',
+    catchup=False,
+    tags=['brewlytics'],
+) as dag:
+    PythonOperator(task_id='etl_cdc_to_star', python_callable=etl_cdc_to_star)
+

--- a/backend-api/Dockerfile
+++ b/backend-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend-api/main.py
+++ b/backend-api/main.py
@@ -1,0 +1,82 @@
+import os
+from datetime import datetime
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+DB_HOST = os.environ.get('OLTP_HOST', 'oltp-db')
+DB_PORT = os.environ.get('OLTP_PORT', '5432')
+DB_USER = os.environ.get('OLTP_USER', 'brew')
+DB_PASSWORD = os.environ.get('OLTP_PASSWORD', 'brew')
+DB_NAME = os.environ.get('OLTP_DB', 'coffee_oltp')
+
+DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+app = FastAPI(title="Brewlytics API")
+
+class Customer(BaseModel):
+    name: str
+    email: str
+
+class Product(BaseModel):
+    name: str
+    price: float
+
+class OrderItem(BaseModel):
+    product_id: int
+    quantity: int
+
+class Order(BaseModel):
+    customer_id: int
+    employee_id: int | None = None
+    items: list[OrderItem]
+
+@app.post("/customers")
+def create_customer(customer: Customer):
+    with engine.begin() as conn:
+        result = conn.execute(
+            text("INSERT INTO customers(name, email) VALUES (:name, :email) RETURNING id"),
+            {"name": customer.name, "email": customer.email},
+        )
+        cid = result.scalar()
+    return {"id": cid, **customer.dict()}
+
+@app.post("/products")
+def create_product(product: Product):
+    with engine.begin() as conn:
+        result = conn.execute(
+            text("INSERT INTO products(name, price) VALUES (:name, :price) RETURNING id"),
+            product.dict(),
+        )
+        pid = result.scalar()
+    return {"id": pid, **product.dict()}
+
+@app.post("/orders")
+def create_order(order: Order):
+    with engine.begin() as conn:
+        result = conn.execute(
+            text("INSERT INTO orders(customer_id, employee_id, order_time) VALUES (:customer_id, :employee_id, :order_time) RETURNING id"),
+            {
+                "customer_id": order.customer_id,
+                "employee_id": order.employee_id or 1,
+                "order_time": datetime.utcnow(),
+            },
+        )
+        order_id = result.scalar()
+        for item in order.items:
+            conn.execute(
+                text(
+                    "INSERT INTO order_items(order_id, product_id, quantity, price) "
+                    "VALUES (:order_id, :product_id, :quantity, (SELECT price FROM products WHERE id=:product_id))"
+                ),
+                {
+                    "order_id": order_id,
+                    "product_id": item.product_id,
+                    "quantity": item.quantity,
+                },
+            )
+    return {"order_id": order_id}

--- a/backend-api/requirements.txt
+++ b/backend-api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+psycopg2-binary
+SQLAlchemy
+python-dotenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3.9'
+services:
+  oltp-db:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: brew
+      POSTGRES_PASSWORD: brew
+      POSTGRES_DB: coffee_oltp
+    volumes:
+      - ./postgres-oltp/init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "5432:5432"
+
+  olap-db:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: brew
+      POSTGRES_PASSWORD: brew
+      POSTGRES_DB: coffee_olap
+    volumes:
+      - ./postgres-olap/init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "5433:5432"
+
+  api:
+    build: ./backend-api
+    environment:
+      OLTP_HOST: oltp-db
+      OLTP_PORT: 5432
+      OLTP_DB: coffee_oltp
+      OLTP_USER: brew
+      OLTP_PASSWORD: brew
+    depends_on:
+      - oltp-db
+    ports:
+      - "8000:8000"
+
+  airflow:
+    image: apache/airflow:2.6.3
+    environment:
+      AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+      AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      OLTP_HOST: oltp-db
+      OLTP_DB: coffee_oltp
+      OLTP_USER: brew
+      OLTP_PASSWORD: brew
+      OLAP_HOST: olap-db
+      OLAP_DB: coffee_olap
+      OLAP_USER: brew
+      OLAP_PASSWORD: brew
+    volumes:
+      - ./airflow-pipeline/dags:/opt/airflow/dags
+    command: bash -c "airflow db init && airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com && airflow scheduler & airflow webserver"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - oltp-db
+      - olap-db
+
+  metabase:
+    image: metabase/metabase
+    ports:
+      - "3000:3000"
+    depends_on:
+      - olap-db
+
+  k6:
+    image: grafana/k6
+    volumes:
+      - ./k6-loadtest:/scripts
+    entrypoint: "k6 run /scripts/loadtest.js"
+    depends_on:
+      - api

--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -1,0 +1,21 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export let options = {
+  stages: [
+    { duration: '30s', target: 10 },
+    { duration: '30s', target: 50 },
+    { duration: '10s', target: 0 },
+  ],
+};
+
+export default function () {
+  const url = 'http://api:8000/orders';
+  const payload = JSON.stringify({
+    customer_id: 1,
+    items: [{ product_id: 1, quantity: 1 }],
+  });
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  http.post(url, payload, params);
+  sleep(1);
+}

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -1,0 +1,8 @@
+This directory holds optional sample configuration for Metabase dashboards.
+
+Sample dashboards include:
+- Revenue by day
+- Sales by category
+- Top customers
+
+You can import dashboard definitions using the Metabase UI after connecting to the `coffee_olap` database.

--- a/metabase/dashboards.json
+++ b/metabase/dashboards.json
@@ -1,0 +1,19 @@
+{
+  "dashboards": [
+    {
+      "name": "Daily Revenue",
+      "description": "Sum of sales per day",
+      "collection": "Brewlytics"
+    },
+    {
+      "name": "Sales by Category",
+      "description": "Product sales aggregated by category",
+      "collection": "Brewlytics"
+    },
+    {
+      "name": "Top Customers",
+      "description": "Customers ranked by total spend",
+      "collection": "Brewlytics"
+    }
+  ]
+}

--- a/postgres-olap/init.sql
+++ b/postgres-olap/init.sql
@@ -1,0 +1,37 @@
+-- OLAP star schema for Brewlytics
+CREATE TABLE dim_customer (
+    id SERIAL PRIMARY KEY,
+    customer_id INTEGER UNIQUE,
+    name TEXT,
+    email TEXT
+);
+
+CREATE TABLE dim_product (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER UNIQUE,
+    name TEXT,
+    price NUMERIC
+);
+
+CREATE TABLE dim_employee (
+    id SERIAL PRIMARY KEY,
+    employee_id INTEGER UNIQUE,
+    name TEXT
+);
+
+CREATE TABLE dim_date (
+    id SERIAL PRIMARY KEY,
+    date DATE UNIQUE
+);
+
+CREATE TABLE fact_sales (
+    id SERIAL PRIMARY KEY,
+    date_id INTEGER REFERENCES dim_date(id),
+    customer_dim_id INTEGER REFERENCES dim_customer(id),
+    product_dim_id INTEGER REFERENCES dim_product(id),
+    employee_dim_id INTEGER REFERENCES dim_employee(id),
+    quantity INTEGER,
+    price NUMERIC,
+    total NUMERIC,
+    order_time TIMESTAMPTZ
+);

--- a/postgres-oltp/init.sql
+++ b/postgres-oltp/init.sql
@@ -1,0 +1,72 @@
+-- OLTP schema for Brewlytics
+CREATE TABLE customers (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL
+);
+INSERT INTO customers(name, email) VALUES
+    ('Alice', 'alice@example.com'),
+    ('Bob', 'bob@example.com');
+
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    price NUMERIC NOT NULL
+);
+INSERT INTO products(name, price) VALUES
+    ('Espresso', 3.00),
+    ('Latte', 4.50),
+    ('Croissant', 2.50);
+
+CREATE TABLE employees (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+INSERT INTO employees(name) VALUES ('System');
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    customer_id INTEGER REFERENCES customers(id),
+    employee_id INTEGER REFERENCES employees(id),
+    order_time TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE order_items (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER REFERENCES orders(id),
+    product_id INTEGER REFERENCES products(id),
+    quantity INTEGER NOT NULL,
+    price NUMERIC NOT NULL
+);
+
+CREATE TABLE cdc_orders (
+    id SERIAL PRIMARY KEY,
+    payload JSONB NOT NULL,
+    processed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION log_order_item_cdc() RETURNS TRIGGER AS $$
+DECLARE
+    o orders%ROWTYPE;
+BEGIN
+    SELECT * INTO o FROM orders WHERE id = NEW.order_id;
+    INSERT INTO cdc_orders(payload)
+    VALUES (
+        jsonb_build_object(
+            'order_id', o.id,
+            'customer_id', o.customer_id,
+            'employee_id', o.employee_id,
+            'order_time', o.order_time,
+            'product_id', NEW.product_id,
+            'quantity', NEW.quantity,
+            'price', NEW.price
+        )
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_order_item_cdc
+AFTER INSERT ON order_items
+FOR EACH ROW EXECUTE PROCEDURE log_order_item_cdc();


### PR DESCRIPTION
## Summary
- include example Metabase dashboard definitions
- expose OLTP/OLAP connection vars to Airflow

## Testing
- `python -m py_compile backend-api/main.py airflow-pipeline/dags/cdc_to_star.py`
- ❌ `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7ce9050c8330afabfe1f78dad4f3