### PR TITLE
Implement Metabase sample dashboard creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,17 @@ K6 will bombard your API like a line of customers 2 minutes before closing.
 
 Use Metabase to visualize sales trends, best-selling items, and which employee is secretly upselling muffins.
 
-Connect Metabase to the OLAP PostgreSQL database. Sample dashboards include:
+Connect Metabase to the OLAP PostgreSQL database.
 
 1. Visit [Metabase](http://localhost:3000) and create an admin user.
 2. Add a new PostgreSQL database using host `olap-db`, port `5432`, user `brew`,
    password `brew`, and database `coffee_olap`.
-
-* Daily revenue breakdown
-* Most caffeinated customers
-* Sales by time of day (a.k.a. “When do people need coffee the most?”)
+3. (Optional) run `python metabase/setup_dashboards.py` to create example
+   dashboards automatically. The script creates a **Coffee Shop Overview**
+   dashboard with:
+   - Daily revenue
+   - Sales by product
+   - Top customers
 
 ## Folder Structure
 

--- a/TODO.md
+++ b/TODO.md
@@ -90,7 +90,7 @@ All components must work together using Docker Compose. Prefer sensible defaults
 
 - [x] Ensure Metabase container connects to OLAP DB
 - [x] Document login steps
-- [ ] Optionally generate sample dashboards:
+- [x] Optionally generate sample dashboards:
   - Daily revenue
   - Sales by category
   - Top customers

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -1,0 +1,23 @@
+# Metabase Dashboards
+
+This folder contains a helper script to bootstrap example dashboards in Metabase.
+
+## Usage
+
+1. Start the Brewlytics stack with `docker-compose up` and finish the Metabase
+   setup wizard (create an admin user and connect the `coffee_olap` database).
+2. Run the setup script:
+
+```bash
+python metabase/setup_dashboards.py
+```
+
+The script uses the Metabase API to create a dashboard named **Coffee Shop
+Overview** with the following cards:
+
+- **Daily Revenue**
+- **Sales by Product**
+- **Top Customers**
+
+You can customise credentials and host via the environment variables
+`METABASE_HOST`, `METABASE_USER`, and `METABASE_PASSWORD`.

--- a/metabase/requirements.txt
+++ b/metabase/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/metabase/setup_dashboards.py
+++ b/metabase/setup_dashboards.py
@@ -1,0 +1,88 @@
+import os
+import requests
+
+MB_HOST = os.environ.get('METABASE_HOST', 'http://localhost:3000')
+MB_USER = os.environ.get('METABASE_USER', 'admin@example.com')
+MB_PASS = os.environ.get('METABASE_PASSWORD', 'admin')
+
+session = requests.Session()
+resp = session.post(f"{MB_HOST}/api/session", json={"username": MB_USER, "password": MB_PASS})
+resp.raise_for_status()
+session.headers.update({'X-Metabase-Session': resp.json()['id']})
+
+def get_database_id(name: str) -> int:
+    resp = session.get(f"{MB_HOST}/api/database")
+    resp.raise_for_status()
+    for db in resp.json():
+        if db.get('name') == name:
+            return db['id']
+    raise SystemExit(f"Database '{name}' not found")
+
+def create_card(name: str, db_id: int, query: str) -> int:
+    payload = {
+        "name": name,
+        "dataset_query": {"database": db_id, "native": {"query": query}},
+        "display": "table",
+    }
+    resp = session.post(f"{MB_HOST}/api/card", json=payload)
+    resp.raise_for_status()
+    return resp.json()['id']
+
+def create_dashboard(name: str) -> int:
+    resp = session.post(f"{MB_HOST}/api/dashboard", json={"name": name})
+    resp.raise_for_status()
+    return resp.json()['id']
+
+def add_card_to_dashboard(dashboard_id: int, card_id: int, col: int) -> None:
+    payload = {"cardId": card_id, "sizeX": 4, "sizeY": 4, "col": col, "row": 0}
+    resp = session.post(f"{MB_HOST}/api/dashboard/{dashboard_id}/cards", json=payload)
+    resp.raise_for_status()
+
+def main():
+    db_id = get_database_id('coffee_olap')
+
+    card_daily = create_card(
+        "Daily Revenue",
+        db_id,
+        """
+        SELECT dd.date AS day, SUM(fs.total) AS revenue
+        FROM fact_sales fs
+        JOIN dim_date dd ON fs.date_id = dd.id
+        GROUP BY dd.date
+        ORDER BY dd.date;
+        """,
+    )
+
+    card_product = create_card(
+        "Sales by Product",
+        db_id,
+        """
+        SELECT dp.name AS product, SUM(fs.total) AS revenue
+        FROM fact_sales fs
+        JOIN dim_product dp ON fs.product_dim_id = dp.id
+        GROUP BY dp.name
+        ORDER BY revenue DESC;
+        """,
+    )
+
+    card_customer = create_card(
+        "Top Customers",
+        db_id,
+        """
+        SELECT dc.name AS customer, SUM(fs.total) AS revenue
+        FROM fact_sales fs
+        JOIN dim_customer dc ON fs.customer_dim_id = dc.id
+        GROUP BY dc.name
+        ORDER BY revenue DESC
+        LIMIT 10;
+        """,
+    )
+
+    dashboard_id = create_dashboard("Coffee Shop Overview")
+    add_card_to_dashboard(dashboard_id, card_daily, 0)
+    add_card_to_dashboard(dashboard_id, card_product, 4)
+    add_card_to_dashboard(dashboard_id, card_customer, 8)
+    print(f"Created dashboard {dashboard_id}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `metabase/` directory
- provide `setup_dashboards.py` script that uses Metabase API to build a sample dashboard
- add documentation and requirements for the new script
- update README with instructions to run the script
- mark TODO item for sample dashboards as complete

## Testing
- `pytest -q` *(fails: ConnectionRefusedError connecting to API)*

------
https://chatgpt.com/codex/tasks/task_e_687b89c1494483308e135820502d79d1