### PR TITLE
Add dbt seeds for customers and products

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,16 @@ If everything works, pat yourself on the back. If not, blame YAML.
 
 ### Generate Sample Data
 
-To quickly populate the OLTP database with example customers, products and
-orders run:
+Flyway provisions both databases automatically. To load additional sample
+customers and products without running the Python script, use dbt seeds:
 
 ```bash
-python backend-api/sample_data.py
+docker-compose run dbt-seed
 ```
 
-This script uses the same connection settings as the API and seeds a handful of
-random orders so the rest of the pipeline has data to work with.
+This will insert a few extra records using the CSV files in the `dbt/seeds`
+folder. The original `backend-api/sample_data.py` script can still be used to
+generate random orders if desired.
 
 ## API Endpoints
 

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,0 +1,11 @@
+name: brewlytics_dbt
+version: '1.0'
+config-version: 2
+
+profile: brewlytics
+
+seeds:
+  brewlytics_dbt:
+    +schema: public
+    +quote_columns: false
+

--- a/dbt/macros/load_static_data.sql
+++ b/dbt/macros/load_static_data.sql
@@ -1,0 +1,9 @@
+{% macro load_static_data() %}
+insert into {{ target.schema }}.customers (name, email)
+select name, email from {{ ref('customers') }}
+on conflict do nothing;
+
+insert into {{ target.schema }}.products (name, price)
+select name, price from {{ ref('products') }}
+on conflict do nothing;
+{% endmacro %}

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,0 +1,11 @@
+brewlytics:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: oltp-db
+      user: brew
+      password: brew
+      port: 5432
+      dbname: coffee_oltp
+      schema: public

--- a/dbt/seed.sh
+++ b/dbt/seed.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+DBT_PROFILES_DIR=${DBT_PROFILES_DIR:-/dbt}
+
+dbt seed --profiles-dir "$DBT_PROFILES_DIR"
+dbt run-operation load_static_data --profiles-dir "$DBT_PROFILES_DIR"

--- a/dbt/seeds/customers.csv
+++ b/dbt/seeds/customers.csv
@@ -1,0 +1,4 @@
+name,email
+Charlie,charlie@example.com
+Dana,dana@example.com
+Eve,eve@example.com

--- a/dbt/seeds/products.csv
+++ b/dbt/seeds/products.csv
@@ -1,0 +1,4 @@
+name,price
+Americano,3.5
+Cappuccino,4.0
+Muffin,2.75

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,3 +90,14 @@ services:
     entrypoint: "k6 run /scripts/loadtest.js"
     depends_on:
       - api
+
+  dbt-seed:
+    image: ghcr.io/dbt-labs/dbt-postgres:1.6.0
+    volumes:
+      - ./dbt:/dbt
+    working_dir: /dbt
+    environment:
+      DBT_PROFILES_DIR: /dbt
+    entrypoint: ["/bin/sh", "-c", "./seed.sh"]
+    depends_on:
+      - flyway-oltp


### PR DESCRIPTION
## Summary
- create dbt project with CSV seeds and macro for loading data
- run seeds via new `dbt-seed` service in docker compose
- document how to load sample data using dbt

## Testing
- `pip install -r backend-api/requirements.txt -r metabase/requirements.txt`
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687b8e0036dc83309ac6937e5040bbdb