### PR TITLE
Split dbt profiles and rename services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Flyway provisions both databases automatically. To load additional sample
 customers and products, use dbt seeds:
 
 ```bash
-docker-compose run dbt-seed
+docker-compose run dbt_oltp
 ```
 
 This inserts a few extra records into the OLTP database using the CSV files in
@@ -81,7 +81,7 @@ the `dbt/seeds` folder.
 To run analytical transformations with dbt models:
 
 ```bash
-docker-compose run dbt-run
+docker-compose run dbt_olap
 ```
 
 This populates helper tables like `daily_sales` in the OLAP database.

--- a/dbt/dbt_olap.sh
+++ b/dbt/dbt_olap.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+DBT_PROFILES_DIR=${DBT_PROFILES_DIR:-/dbt}
+DBT_PROFILE=${DBT_PROFILE:-olap}
+DBT_TARGET=${DBT_TARGET:-dev}
+
+dbt run --profiles-dir "$DBT_PROFILES_DIR" --profile "$DBT_PROFILE" --target "$DBT_TARGET"

--- a/dbt/dbt_oltp.sh
+++ b/dbt/dbt_oltp.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+DBT_PROFILES_DIR=${DBT_PROFILES_DIR:-/dbt}
+DBT_PROFILE=${DBT_PROFILE:-oltp}
+DBT_TARGET=${DBT_TARGET:-dev}
+
+dbt seed --profiles-dir "$DBT_PROFILES_DIR" --profile "$DBT_PROFILE" --target "$DBT_TARGET"
+dbt run-operation load_static_data --profiles-dir "$DBT_PROFILES_DIR" --profile "$DBT_PROFILE" --target "$DBT_TARGET"
+# Insert a sample order so OLTP has data to replicate
+dbt run-operation insert_sample_orders --profiles-dir "$DBT_PROFILES_DIR" --profile "$DBT_PROFILE" --target "$DBT_TARGET"

--- a/dbt/macros/insert_sample_orders.sql
+++ b/dbt/macros/insert_sample_orders.sql
@@ -1,0 +1,8 @@
+{% macro insert_sample_orders() %}
+insert into {{ target.schema }}.orders (customer_id, employee_id, order_time)
+values (1, 1, now());
+insert into {{ target.schema }}.order_items (order_id, product_id, quantity, price)
+select currval(pg_get_serial_sequence('{{ target.schema }}.orders','id')),
+       1, 1,
+       price from {{ target.schema }}.products limit 1;
+{% endmacro %}

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,4 +1,4 @@
-brewlytics:
+oltp:
   target: dev
   outputs:
     dev:
@@ -9,7 +9,11 @@ brewlytics:
       port: 5432
       dbname: coffee_oltp
       schema: public
-    olap:
+
+olap:
+  target: dev
+  outputs:
+    dev:
       type: postgres
       host: olap-db
       user: brew

--- a/dbt/run.sh
+++ b/dbt/run.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-DBT_PROFILES_DIR=${DBT_PROFILES_DIR:-/dbt}
-DBT_TARGET=${DBT_TARGET:-olap}
-
-dbt run --profiles-dir "$DBT_PROFILES_DIR" --target "$DBT_TARGET"

--- a/dbt/seed.sh
+++ b/dbt/seed.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-DBT_PROFILES_DIR=${DBT_PROFILES_DIR:-/dbt}
-DBT_TARGET=${DBT_TARGET:-oltp}
-
-dbt seed --profiles-dir "$DBT_PROFILES_DIR" --target "$DBT_TARGET"
-dbt run-operation load_static_data --profiles-dir "$DBT_PROFILES_DIR" --target "$DBT_TARGET"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,26 +91,28 @@ services:
     depends_on:
       - api
 
-  dbt-seed:
+  dbt_oltp:
     image: ghcr.io/dbt-labs/dbt-postgres:1.6.0
     volumes:
       - ./dbt:/dbt
     working_dir: /dbt
     environment:
       DBT_PROFILES_DIR: /dbt
-      DBT_TARGET: oltp
-    entrypoint: ["/bin/sh", "-c", "./seed.sh"]
+      DBT_PROFILE: oltp
+      DBT_TARGET: dev
+    entrypoint: ["/bin/sh", "-c", "./dbt_oltp.sh"]
     depends_on:
       - flyway-oltp
 
-  dbt-run:
+  dbt_olap:
     image: ghcr.io/dbt-labs/dbt-postgres:1.6.0
     volumes:
       - ./dbt:/dbt
     working_dir: /dbt
     environment:
       DBT_PROFILES_DIR: /dbt
-      DBT_TARGET: olap
-    entrypoint: ["/bin/sh", "-c", "./run.sh"]
+      DBT_PROFILE: olap
+      DBT_TARGET: dev
+    entrypoint: ["/bin/sh", "-c", "./dbt_olap.sh"]
     depends_on:
       - flyway-olap


### PR DESCRIPTION
## Summary
- add `oltp` and `olap` profiles for dbt
- rename dbt scripts and compose services to `dbt_oltp` and `dbt_olap`
- update README for new service names
- add macro and command to insert a sample order during the OLTP phase

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687b934a83ec83308f5dc4b622d3e4e7