### PR TITLE
Remove sample data from Flyway migrations

### DIFF
--- a/flyway/migrations/olap/V1__init.sql
+++ b/flyway/migrations/olap/V1__init.sql
@@ -36,15 +36,3 @@ CREATE TABLE fact_sales (
     order_time TIMESTAMPTZ
 );
 
-INSERT INTO dim_customer(customer_id, name, email) VALUES
-    (1, 'Alice', 'alice@example.com');
-INSERT INTO dim_product(product_id, name, price) VALUES
-    (1, 'Espresso', 3.00);
-INSERT INTO dim_employee(employee_id, name) VALUES
-    (1, 'System');
-INSERT INTO dim_date(date) VALUES ('2023-01-01');
-
-INSERT INTO fact_sales(date_id, customer_dim_id, product_dim_id, employee_dim_id, quantity, price, total, order_time)
-SELECT dd.id, dc.id, dp.id, de.id, 1, 3.00, 3.00, '2023-01-01'
-FROM dim_date dd, dim_customer dc, dim_product dp, dim_employee de
-WHERE dd.date='2023-01-01' AND dc.customer_id=1 AND dp.product_id=1 AND de.employee_id=1;

--- a/flyway/migrations/oltp/V1__init.sql
+++ b/flyway/migrations/oltp/V1__init.sql
@@ -4,25 +4,17 @@ CREATE TABLE customers (
     name TEXT NOT NULL,
     email TEXT NOT NULL
 );
-INSERT INTO customers(name, email) VALUES
-    ('Alice', 'alice@example.com'),
-    ('Bob', 'bob@example.com');
 
 CREATE TABLE products (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
     price NUMERIC NOT NULL
 );
-INSERT INTO products(name, price) VALUES
-    ('Espresso', 3.00),
-    ('Latte', 4.50),
-    ('Croissant', 2.50);
 
 CREATE TABLE employees (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL
 );
-INSERT INTO employees(name) VALUES ('System');
 
 CREATE TABLE orders (
     id SERIAL PRIMARY KEY,

--- a/flyway/migrations/oltp/V2__cdc_offset_update_delete.sql
+++ b/flyway/migrations/oltp/V2__cdc_offset_update_delete.sql
@@ -5,9 +5,6 @@ CREATE TABLE IF NOT EXISTS cdc_offset (
     table_name TEXT PRIMARY KEY,
     last_id INTEGER DEFAULT 0
 );
-INSERT INTO cdc_offset(table_name, last_id)
-    VALUES ('cdc_orders', 0)
-ON CONFLICT (table_name) DO NOTHING;
 
 -- extend cdc_orders with operation and table name
 ALTER TABLE cdc_orders ADD COLUMN IF NOT EXISTS op TEXT DEFAULT 'INSERT';


### PR DESCRIPTION
## Summary
- strip static inserts from OLTP and OLAP Flyway migrations
- remove default `cdc_offset` seed row

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687b96a41ab48330819f698578cf576a