### PR TITLE
Scale order-api via docker-compose

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -132,7 +132,7 @@ All components must work together using Docker Compose. Prefer sensible defaults
   - occasionally create new customers and products during tests
 - [ ] Refactor backend into microservices for separate order, product, and customer APIs
 - [x] Use Flyway to manage and deploy database schema changes
-- [ ] Configure `docker-compose.yml` to scale services:
+- [x] Configure `docker-compose.yml` to scale services:
   - `order-api` runs 3 instances
   - other API services run 1 instance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,10 @@ services:
     depends_on:
       - flyway-olap
 
-  api:
+  order-api:
     build: ./backend-api
+    deploy:
+      replicas: 3
     environment:
       OLTP_HOST: oltp-db
       OLTP_PORT: 5432
@@ -115,5 +117,5 @@ services:
       - ./k6-loadtest:/scripts
     entrypoint: "k6 run /scripts/loadtest.js"
     depends_on:
-      - api
+      - order-api
 

--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -11,7 +11,7 @@ export let options = {
 };
 
 export default function () {
-  const url = 'http://api:8000/orders';
+  const url = 'http://order-api:8000/orders';
   const payload = JSON.stringify({
     customer_id: 1,
     items: [{ product_id: 1, quantity: 1 }],


### PR DESCRIPTION
## Summary
- scale the API service as outlined in `TODO.md`
- update k6 load test to target the new service name
- mark scaling task complete in `TODO.md`

## Testing
- `pytest -q` *(fails: ConnectionError - refused connection)*

------
https://chatgpt.com/codex/tasks/task_e_687ba00d7ce88330b1d88213668b6416