### PR TITLE
Add API gateway reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ cd brewlytics
 docker-compose up --build
 ```
 
-* Order API: `http://localhost:8000`
-* Product API: `http://localhost:8001`
-* Customer API: `http://localhost:8002`
+* API Gateway: `http://localhost:8000`
 * Airflow: `http://localhost:8080`
 * Metabase: `http://localhost:3000`
 * Flyway runs automatically to provision both databases

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,6 @@ services:
       OLTP_PASSWORD: brew
     depends_on:
       - flyway-oltp
-    ports:
-      - "8000:8000"
 
   product-api:
     build: ./product-api
@@ -93,8 +91,6 @@ services:
       OLTP_PASSWORD: brew
     depends_on:
       - flyway-oltp
-    ports:
-      - "8001:8000"
 
   customer-api:
     build: ./customer-api
@@ -106,8 +102,15 @@ services:
       OLTP_PASSWORD: brew
     depends_on:
       - flyway-oltp
+
+  gateway:
+    build: ./gateway
+    depends_on:
+      - order-api
+      - product-api
+      - customer-api
     ports:
-      - "8002:8000"
+      - "8000:80"
 
   airflow:
     image: apache/airflow:2.6.3
@@ -143,5 +146,5 @@ services:
       - ./k6-loadtest:/scripts
     entrypoint: "k6 run /scripts/loadtest.js"
     depends_on:
-      - order-api
+      - gateway
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    upstream order_api {
+        server order-api:8000;
+    }
+    upstream product_api {
+        server product-api:8000;
+    }
+    upstream customer_api {
+        server customer-api:8000;
+    }
+
+    server {
+        listen 80;
+
+        location /orders/ {
+            proxy_pass http://order_api/;
+        }
+
+        location /products/ {
+            proxy_pass http://product_api/;
+        }
+
+        location /customers/ {
+            proxy_pass http://customer_api/;
+        }
+    }
+}

--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -11,7 +11,7 @@ export let options = {
 };
 
 export default function () {
-  const url = 'http://order-api:8000/orders';
+  const url = 'http://gateway:80/orders';
   const payload = JSON.stringify({
     customer_id: 1,
     items: [{ product_id: 1, quantity: 1 }],


### PR DESCRIPTION
## Summary
- add nginx-based gateway service
- expose /orders, /products and /customers through the gateway
- route load tests through the gateway
- update README documentation
- update docker-compose stack

## Testing
- `pytest -q` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687ba4ac5bd48330913b4aa8f7bcb9da