### PR TITLE
Finish env migration and loadtest update

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,10 @@
+DB_USER=brew
+DB_PASSWORD=brew
+OLTP_DB=coffee_oltp
+OLAP_DB=coffee_olap
+OLTP_HOST=oltp-db
+OLTP_PORT=5432
+OLAP_HOST=olap-db
+OLAP_PORT=5432
+MB_DB=metabase
+API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Whether you're brewing orders, piping SQL, or stirring Airflow DAGs, Brewlytics 
 ```bash
 git clone https://github.com/babanomania/brewlytics.git
 cd brewlytics
+cp .env.sample .env
+# Review and adjust values in `.env` if needed
 ```
 
 ### Start the System

--- a/TODO.md
+++ b/TODO.md
@@ -124,10 +124,10 @@ All components must work together using Docker Compose. Prefer sensible defaults
 
 ---
 
-## 11. Additional Features
+-## 11. Additional Features
 
-- [ ] Secure `docker-compose.yml` by moving all passwords into `.env.sample`
-- [ ] Expand load testing with variations:
+- [x] Secure `docker-compose.yml` by moving all passwords into `.env.sample`
+- [x] Expand load testing with variations:
   - randomize customers and products
   - occasionally create new customers and products during tests
 - [x] Refactor backend into microservices for separate order, product, and customer APIs

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -3,11 +3,11 @@ oltp:
   outputs:
     dev:
       type: postgres
-      host: oltp-db
-      user: brew
-      password: brew
-      port: 5432
-      dbname: coffee_oltp
+      host: "{{ env_var('OLTP_HOST', 'oltp-db') }}"
+      user: "{{ env_var('DB_USER', 'brew') }}"
+      password: "{{ env_var('DB_PASSWORD', 'brew') }}"
+      port: {{ env_var('OLTP_PORT', '5432') }}
+      dbname: "{{ env_var('OLTP_DB', 'coffee_oltp') }}"
       schema: public
 
 olap:
@@ -15,9 +15,9 @@ olap:
   outputs:
     dev:
       type: postgres
-      host: olap-db
-      user: brew
-      password: brew
-      port: 5432
-      dbname: coffee_olap
+      host: "{{ env_var('OLAP_HOST', 'olap-db') }}"
+      user: "{{ env_var('DB_USER', 'brew') }}"
+      password: "{{ env_var('DB_PASSWORD', 'brew') }}"
+      port: {{ env_var('OLAP_PORT', '5432') }}
+      dbname: "{{ env_var('OLAP_DB', 'coffee_olap') }}"
       schema: public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@ version: '3.9'
 services:
   oltp-db:
     image: postgres:14
+    env_file: .env
     environment:
-      POSTGRES_USER: brew
-      POSTGRES_PASSWORD: brew
-      POSTGRES_DB: coffee_oltp
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${OLTP_DB}
     ports:
       - "5432:5432"
 
@@ -14,10 +15,11 @@ services:
     command: -connectRetries=60 migrate
     volumes:
       - ./flyway/migrations/oltp:/flyway/sql
+    env_file: .env
     environment:
-      FLYWAY_URL: jdbc:postgresql://oltp-db:5432/coffee_oltp
-      FLYWAY_USER: brew
-      FLYWAY_PASSWORD: brew
+      FLYWAY_URL: jdbc:postgresql://${OLTP_HOST}:${OLTP_PORT}/${OLTP_DB}
+      FLYWAY_USER: ${DB_USER}
+      FLYWAY_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - oltp-db
 
@@ -26,6 +28,7 @@ services:
     volumes:
       - ./dbt:/dbt
     working_dir: /dbt
+    env_file: .env
     environment:
       DBT_PROFILES_DIR: /dbt
       DBT_PROFILE: oltp
@@ -36,10 +39,11 @@ services:
 
   olap-db:
     image: postgres:14
+    env_file: .env
     environment:
-      POSTGRES_USER: brew
-      POSTGRES_PASSWORD: brew
-      POSTGRES_DB: coffee_olap
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${OLAP_DB}
     ports:
       - "5433:5432"
 
@@ -48,10 +52,11 @@ services:
     command: -connectRetries=60 migrate
     volumes:
       - ./flyway/migrations/olap:/flyway/sql
+    env_file: .env
     environment:
-      FLYWAY_URL: jdbc:postgresql://olap-db:5432/coffee_olap
-      FLYWAY_USER: brew
-      FLYWAY_PASSWORD: brew
+      FLYWAY_URL: jdbc:postgresql://${OLAP_HOST}:${OLAP_PORT}/${OLAP_DB}
+      FLYWAY_USER: ${DB_USER}
+      FLYWAY_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - olap-db
 
@@ -60,6 +65,7 @@ services:
     volumes:
       - ./dbt:/dbt
     working_dir: /dbt
+    env_file: .env
     environment:
       DBT_PROFILES_DIR: /dbt
       DBT_PROFILE: olap
@@ -72,34 +78,37 @@ services:
     build: ./backend-api/order-api
     deploy:
       replicas: 3
+    env_file: .env
     environment:
-      OLTP_HOST: oltp-db
-      OLTP_PORT: 5432
-      OLTP_DB: coffee_oltp
-      OLTP_USER: brew
-      OLTP_PASSWORD: brew
+      OLTP_HOST: ${OLTP_HOST}
+      OLTP_PORT: ${OLTP_PORT}
+      OLTP_DB: ${OLTP_DB}
+      OLTP_USER: ${DB_USER}
+      OLTP_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - flyway-oltp
 
   product-api:
     build: ./backend-api/product-api
+    env_file: .env
     environment:
-      OLTP_HOST: oltp-db
-      OLTP_PORT: 5432
-      OLTP_DB: coffee_oltp
-      OLTP_USER: brew
-      OLTP_PASSWORD: brew
+      OLTP_HOST: ${OLTP_HOST}
+      OLTP_PORT: ${OLTP_PORT}
+      OLTP_DB: ${OLTP_DB}
+      OLTP_USER: ${DB_USER}
+      OLTP_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - flyway-oltp
 
   customer-api:
     build: ./backend-api/customer-api
+    env_file: .env
     environment:
-      OLTP_HOST: oltp-db
-      OLTP_PORT: 5432
-      OLTP_DB: coffee_oltp
-      OLTP_USER: brew
-      OLTP_PASSWORD: brew
+      OLTP_HOST: ${OLTP_HOST}
+      OLTP_PORT: ${OLTP_PORT}
+      OLTP_DB: ${OLTP_DB}
+      OLTP_USER: ${DB_USER}
+      OLTP_PASSWORD: ${DB_PASSWORD}
     depends_on:
       - flyway-oltp
 
@@ -128,13 +137,14 @@ services:
 
   metabase:
     image: metabase/metabase
+    env_file: .env
     environment:
       MB_DB_TYPE: postgres
-      MB_DB_DBNAME: metabase
-      MB_DB_PORT: 5432
-      MB_DB_HOST: olap-db
-      MB_DB_USER: brew
-      MB_DB_PASS: brew
+      MB_DB_DBNAME: ${MB_DB}
+      MB_DB_PORT: ${OLAP_PORT}
+      MB_DB_HOST: ${OLAP_HOST}
+      MB_DB_USER: ${DB_USER}
+      MB_DB_PASS: ${DB_PASSWORD}
     ports:
       - "3000:3000"
     depends_on:

--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -115,6 +115,20 @@ export default function (data) {
   const apiUrl = __ENV.API_URL || 'http://localhost:8000';
   const headers = { 'Content-Type': 'application/json' };
 
+  if (Math.random() < 0.05) {
+    const res = http.post(`${apiUrl}/customers`, JSON.stringify(generateCustomer()), { headers });
+    if (res.status === 200) {
+      data.customerIds.push(res.json('id'));
+    }
+  }
+
+  if (Math.random() < 0.05) {
+    const res = http.post(`${apiUrl}/products`, JSON.stringify(generateProduct()), { headers });
+    if (res.status === 200) {
+      data.productIds.push(res.json('id'));
+    }
+  }
+
   const customerId = data.customerIds[randomInt(0, data.customerIds.length - 1)];
   const numItems = randomInt(1, 3); // 1-3 items
   const items = [];

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,11 +1,24 @@
 import os
+from dotenv import load_dotenv, find_dotenv
+
+load_dotenv(find_dotenv())
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
+
 OLTP_DSN = os.getenv(
     "OLTP_DSN",
-    "dbname=coffee_oltp user=brew password=brew host=localhost port=5432",
+    f"dbname={os.getenv('OLTP_DB', 'coffee_oltp')} "
+    f"user={os.getenv('DB_USER', 'brew')} "
+    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"host={os.getenv('OLTP_HOST', 'localhost')} "
+    f"port={os.getenv('OLTP_PORT', '5432')}",
 )
+
 OLAP_DSN = os.getenv(
     "OLAP_DSN",
-    "dbname=coffee_olap user=brew password=brew host=localhost port=5433",
+    f"dbname={os.getenv('OLAP_DB', 'coffee_olap')} "
+    f"user={os.getenv('DB_USER', 'brew')} "
+    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"host={os.getenv('OLAP_HOST', 'localhost')} "
+    f"port={os.getenv('OLAP_PORT', '5433')}",
 )


### PR DESCRIPTION
## Summary
- manage DB names and credentials via `.env`
- load from env in pytest config
- inject env variables in docker-compose
- parameterize dbt profiles with env vars
- create `.env.sample`
- add dynamic customer/product creation in load test
- document env step in README
- check off completed items in TODO

## Testing
- `pip install requests psycopg2-binary python-dotenv`
- `pytest -q` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687babd208808330bd6962fad19b19b9