### PR TITLE
Fix dashboard config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,15 @@ Connect Metabase to the OLAP PostgreSQL database.
 1. Visit [Metabase](http://localhost:3000) and create an admin user.
 2. Add a new PostgreSQL database using host `olap-db`, port `5432`, user `brew`,
    password `brew`, and database `coffee_olap`.
-3. (Optional) customise `dashboard.json` and run
-   `python metabase/dashboard_from_config.py` to create an example dashboard
+3. (Optional) customise `metabase/dashboard.json` and run
+   `python metabase/setup_dashboards.py` to create an example dashboard
    automatically. The script reads the config file path from the
-   `DASHBOARD_CONFIG` environment variable (defaults to `dashboard.json`).
+   `DASHBOARD_CONFIG` environment variable (defaults to `metabase/dashboard.json`).
 
 You can also customise the dashboard by providing a JSON config file and
-running `python metabase/dashboard_from_config.py`. The script reads the file
+running `python metabase/setup_dashboards.py`. The script reads the file
 path from the `DASHBOARD_CONFIG` environment variable (defaults to
-`dashboard.json`).
+`metabase/dashboard.json`).
 
 ## Running Tests
 

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -6,7 +6,7 @@ This folder contains a helper script to bootstrap example dashboards in Metabase
 
 1. Start the Brewlytics stack with `docker-compose up` and finish the Metabase
    setup wizard (create an admin user and connect the `coffee_olap` database).
-2. (Optional) edit `dashboard.json` to customise the dashboard name and SQL
+2. (Optional) edit `dashboard.json` in this directory to customise the dashboard name and SQL
    queries.
 3. Run the script:
 
@@ -14,7 +14,7 @@ This folder contains a helper script to bootstrap example dashboards in Metabase
 python metabase/setup_dashboards.py
 ```
 
-The script reads the configuration from `dashboard.json` (or the path specified
+The script reads the configuration from the `dashboard.json` file in this directory (or the path specified
 in the `DASHBOARD_CONFIG` environment variable) and creates the dashboard using
 the Metabase API. The environment variables `METABASE_HOST`, `METABASE_USER`,
 and `METABASE_PASSWORD` can be used to override the defaults.

--- a/metabase/setup_dashboards.py
+++ b/metabase/setup_dashboards.py
@@ -86,7 +86,9 @@ def main() -> None:
     host = os.environ.get("METABASE_HOST", "http://localhost:3000")
     user = os.environ.get("METABASE_USER", "admin@example.com")
     password = os.environ.get("METABASE_PASSWORD", "admin")
-    config_path = os.environ.get("DASHBOARD_CONFIG", "dashboard.json")
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    default_config = os.path.join(script_dir, "dashboard.json")
+    config_path = os.environ.get("DASHBOARD_CONFIG", default_config)
 
     config = load_config(config_path)
 


### PR DESCRIPTION
## Summary
- default dashboard setup script config to `metabase/dashboard.json`
- clarify README instructions

## Testing
- `pytest -q` *(fails: ConnectionError to localhost)*

------
https://chatgpt.com/codex/tasks/task_e_687bb11f5b288330bb1912d457314e0a