### PR TITLE
Remove test DSN defaults

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -5,20 +5,31 @@ load_dotenv(find_dotenv())
 
 API_URL = os.getenv("API_URL", "http://localhost:8000")
 
+# Required database configuration values
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+OLTP_DB = os.getenv("OLTP_DB")
+OLAP_DB = os.getenv("OLAP_DB")
+
+if not all([DB_USER, DB_PASSWORD, OLTP_DB, OLAP_DB]):
+    raise RuntimeError(
+        "DB_USER, DB_PASSWORD, OLTP_DB and OLAP_DB must be provided in the .env file"
+    )
+
 OLTP_DSN = os.getenv(
     "OLTP_DSN",
-    f"dbname={os.getenv('OLTP_DB', 'coffee_oltp')} "
-    f"user={os.getenv('DB_USER', 'brew')} "
-    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"dbname={OLTP_DB} "
+    f"user={DB_USER} "
+    f"password={DB_PASSWORD} "
     f"host={os.getenv('OLTP_HOST', 'localhost')} "
     f"port={os.getenv('OLTP_PORT', '5432')}",
 )
 
 OLAP_DSN = os.getenv(
     "OLAP_DSN",
-    f"dbname={os.getenv('OLAP_DB', 'coffee_olap')} "
-    f"user={os.getenv('DB_USER', 'brew')} "
-    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"dbname={OLAP_DB} "
+    f"user={DB_USER} "
+    f"password={DB_PASSWORD} "
     f"host={os.getenv('OLAP_HOST', 'localhost')} "
     f"port={os.getenv('OLAP_PORT', '5433')}",
 )


### PR DESCRIPTION
## Summary
- make DB connection settings mandatory for the tests

## Testing
- `ruff check tests/config.py`
- `black --check tests/config.py`
- `pytest -q` *(fails: ConnectionError when contacting localhost)*

------
https://chatgpt.com/codex/tasks/task_e_687bb1c049e483308149057b4397d20e