### PR TITLE
Fix db credentials

### DIFF
--- a/airflow-pipeline/dags/cdc_to_star.py
+++ b/airflow-pipeline/dags/cdc_to_star.py
@@ -8,15 +8,15 @@ import psycopg2
 def etl_cdc_to_star():
     oltp = psycopg2.connect(
         host=os.environ.get('OLTP_HOST', 'oltp-db'),
-        database=os.environ.get('OLTP_DB', 'coffee_oltp'),
-        user=os.environ.get('OLTP_USER', 'brew'),
-        password=os.environ.get('OLTP_PASSWORD', 'brew'),
+        database=os.environ.get('OLTP_DB'),
+        user=os.environ.get('DB_USER'),
+        password=os.environ.get('DB_PASSWORD'),
     )
     olap = psycopg2.connect(
         host=os.environ.get('OLAP_HOST', 'olap-db'),
-        database=os.environ.get('OLAP_DB', 'coffee_olap'),
-        user=os.environ.get('OLAP_USER', 'brew'),
-        password=os.environ.get('OLAP_PASSWORD', 'brew'),
+        database=os.environ.get('OLAP_DB'),
+        user=os.environ.get('DB_USER'),
+        password=os.environ.get('DB_PASSWORD'),
     )
     oltp.autocommit = True
     olap.autocommit = True

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -4,10 +4,10 @@ oltp:
     dev:
       type: postgres
       host: "{{ env_var('OLTP_HOST', 'oltp-db') }}"
-      user: "{{ env_var('DB_USER', 'brew') }}"
-      password: "{{ env_var('DB_PASSWORD', 'brew') }}"
+      user: "{{ env_var('DB_USER') }}"
+      password: "{{ env_var('DB_PASSWORD') }}"
       port: {{ env_var('OLTP_PORT', '5432') }}
-      dbname: "{{ env_var('OLTP_DB', 'coffee_oltp') }}"
+      dbname: "{{ env_var('OLTP_DB') }}"
       schema: public
 
 olap:
@@ -16,8 +16,8 @@ olap:
     dev:
       type: postgres
       host: "{{ env_var('OLAP_HOST', 'olap-db') }}"
-      user: "{{ env_var('DB_USER', 'brew') }}"
-      password: "{{ env_var('DB_PASSWORD', 'brew') }}"
+      user: "{{ env_var('DB_USER') }}"
+      password: "{{ env_var('DB_PASSWORD') }}"
       port: {{ env_var('OLAP_PORT', '5432') }}
-      dbname: "{{ env_var('OLAP_DB', 'coffee_olap') }}"
+      dbname: "{{ env_var('OLAP_DB') }}"
       schema: public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
 
   airflow:
     image: apache/airflow:2.6.3
+    env_file: .env
     environment:
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/tests/config.py
+++ b/tests/config.py
@@ -7,18 +7,18 @@ API_URL = os.getenv("API_URL", "http://localhost:8000")
 
 OLTP_DSN = os.getenv(
     "OLTP_DSN",
-    f"dbname={os.getenv('OLTP_DB', 'coffee_oltp')} "
-    f"user={os.getenv('DB_USER', 'brew')} "
-    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"dbname={os.getenv('OLTP_DB')} "
+    f"user={os.getenv('DB_USER')} "
+    f"password={os.getenv('DB_PASSWORD')} "
     f"host={os.getenv('OLTP_HOST', 'localhost')} "
     f"port={os.getenv('OLTP_PORT', '5432')}",
 )
 
 OLAP_DSN = os.getenv(
     "OLAP_DSN",
-    f"dbname={os.getenv('OLAP_DB', 'coffee_olap')} "
-    f"user={os.getenv('DB_USER', 'brew')} "
-    f"password={os.getenv('DB_PASSWORD', 'brew')} "
+    f"dbname={os.getenv('OLAP_DB')} "
+    f"user={os.getenv('DB_USER')} "
+    f"password={os.getenv('DB_PASSWORD')} "
     f"host={os.getenv('OLAP_HOST', 'localhost')} "
     f"port={os.getenv('OLAP_PORT', '5433')}",
 )


### PR DESCRIPTION
## Summary
- add `.env` to airflow service
- read db creds from environment in `cdc_to_star`
- stop hardcoding db creds in dbt profiles
- remove default creds from tests

## Testing
- `pytest -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_687bb25e778c8330b2571c404c14b76f