### PR TITLE
Fix Metabase start failure due to missing DB

### DIFF
--- a/flyway/migrations/olap/V2__create_metabase_db.sql
+++ b/flyway/migrations/olap/V2__create_metabase_db.sql
@@ -1,0 +1,6 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_database WHERE datname = 'metabase') THEN
+        CREATE DATABASE metabase;
+    END IF;
+END$$;


### PR DESCRIPTION
## Summary
- add Flyway migration to create `metabase` database if it doesn't exist

## Testing
- `pip install requests`
- `pip install python-dotenv`
- `pip install psycopg2-binary`
- `pytest -q` *(fails: ConnectionError because Docker daemon isn't running)*
- `docker-compose up -d` *(fails: Docker daemon not available)*

------
https://chatgpt.com/codex/tasks/task_e_687bb84fad3483309e604ca6ff3b6990