### PR TITLE
Add Postgres health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       POSTGRES_DB: ${OLTP_DB}
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   flyway-oltp:
     image: flyway/flyway
@@ -46,6 +52,12 @@ services:
       POSTGRES_DB: ${OLAP_DB}
     ports:
       - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   flyway-olap:
     image: flyway/flyway
@@ -157,5 +169,10 @@ services:
       - ./k6-loadtest:/scripts
     entrypoint: "k6 run /scripts/loadtest.js"
     depends_on:
-      - gateway
+      gateway:
+        condition: service_started
+      oltp-db:
+        condition: service_healthy
+      olap-db:
+        condition: service_healthy
 


### PR DESCRIPTION
## Summary
- add health checks for OLTP and OLAP Postgres services
- require both databases to be healthy before starting k6 load test

## Testing
- `pytest -q` *(fails: ConnectionError to localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_687bb93e4b8483309e1d387d5cfc4830