### PR TITLE
Add persistent volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ cp .env.sample .env
 ```bash
 docker-compose up --build
 ```
+The Postgres and Metabase containers store their data in named volumes, so your
+databases survive `docker-compose down`.
 
 * API Gateway: `http://localhost:8000`
 * Airflow: `http://localhost:8080`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_DB: ${OLTP_DB}
     ports:
       - "5432:5432"
+    volumes:
+      - oltp-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
@@ -51,6 +53,8 @@ services:
       POSTGRES_DB: ${OLAP_DB}
     ports:
       - "5433:5432"
+    volumes:
+      - olap-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
@@ -159,6 +163,8 @@ services:
       MB_DB_PASS: ${DB_PASSWORD}
     ports:
       - "3000:3000"
+    volumes:
+      - metabase-data:/metabase-data
     depends_on:
       - flyway-olap
 
@@ -174,4 +180,9 @@ services:
         condition: service_healthy
       olap-db:
         condition: service_healthy
+
+volumes:
+  oltp-data:
+  olap-data:
+  metabase-data:
 


### PR DESCRIPTION
## Summary
- persist PostgreSQL and Metabase data via named volumes
- mention volume usage in README

## Testing
- `python - <<'PY'
import yaml
import sys
yaml.safe_load(open('docker-compose.yml'))
print('YAML OK')
PY
`
- `pytest -q` *(fails: ConnectionError when hitting local services)*

------
https://chatgpt.com/codex/tasks/task_e_687bbaa368388330af18c8471711ae52