### PR TITLE
Add dedicated metabase-db service

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,12 @@ cp .env.sample .env
 ```bash
 docker-compose up --build
 ```
-The Postgres and Metabase containers store their data in named volumes, so your
-databases survive `docker-compose down`.
+All Postgres containers (oltp-db, olap-db and metabase-db) store their data in named volumes, so your databases survive `docker-compose down`.
 
 * API Gateway: `http://localhost:8000`
 * Airflow: `http://localhost:8080`
 * Metabase: `http://localhost:3000`
-* Flyway runs automatically to provision both databases
+* Flyway runs automatically to provision all databases
 
 If everything works, pat yourself on the back. If not, blame YAML.
 
@@ -108,6 +107,7 @@ DB_USER=brew
 DB_PASSWORD=brew
 OLTP_DB=coffee_oltp
 OLAP_DB=coffee_olap
+MB_DB=metabase
 ```
 
 These variables are passed to Flyway, Airflow, dbt and the integration tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,24 @@ services:
       retries: 5
       start_period: 5s
 
+  metabase-db:
+    image: postgres:14
+    env_file: .env
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${MB_DB}
+    ports:
+      - "5434:5432"
+    volumes:
+      - metabase-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
   flyway-olap:
     image: flyway/flyway
     command: -connectRetries=60 migrate
@@ -158,7 +176,7 @@ services:
       MB_DB_TYPE: postgres
       MB_DB_DBNAME: ${MB_DB}
       MB_DB_PORT: 5432
-      MB_DB_HOST: olap-db
+      MB_DB_HOST: metabase-db
       MB_DB_USER: ${DB_USER}
       MB_DB_PASS: ${DB_PASSWORD}
     ports:
@@ -167,6 +185,7 @@ services:
       - metabase-data:/metabase-data
     depends_on:
       - flyway-olap
+      - metabase-db
 
   k6:
     image: grafana/k6
@@ -185,4 +204,5 @@ volumes:
   oltp-data:
   olap-data:
   metabase-data:
+  metabase-db-data:
 


### PR DESCRIPTION
## Summary
- spin up a new `metabase-db` Postgres container
- point the Metabase container at the new database and depend on it
- persist Metabase DB data with a volume
- document the new settings in the README

## Testing
- `pytest -q` *(fails: ConnectionError to localhost:8000)*

------
https://chatgpt.com/codex/tasks/task_e_687bbc056d58833094fc5ef4210eb92b