### PR TITLE
Fix nginx redirect to retain port

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -16,6 +16,11 @@ http {
     server {
         listen 80;
 
+        # preserve original host and port when proxying so backend redirects
+        # contain the correct port instead of defaulting to 80
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+
         location /orders/ {
             proxy_pass http://order_api/;
         }


### PR DESCRIPTION
## Summary
- preserve the original host header in the gateway config
- disable `proxy_redirect` so redirects keep port 8000

## Testing
- `pytest -q` *(fails: ConnectionError: Failed to establish a new connection)*

------
https://chatgpt.com/codex/tasks/task_e_687bbf25ce5c8330b332895a89f694cf