### PR TITLE
Fix nginx redirect to retain port

### DIFF
--- a/backend-api/customer-api/Dockerfile
+++ b/backend-api/customer-api/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/backend-api/order-api/Dockerfile
+++ b/backend-api/order-api/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/backend-api/product-api/Dockerfile
+++ b/backend-api/product-api/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -16,6 +16,13 @@ http {
     server {
         listen 80;
 
+        # preserve original host and port when proxying so backend redirects
+        # contain the correct port instead of defaulting to 80
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_redirect off;
+
         location /orders/ {
             proxy_pass http://order_api/;
         }


### PR DESCRIPTION
## Summary
- forward X-Forwarded headers in nginx
- run uvicorn with `--proxy-headers` to respect forwarded host

## Testing
- `pytest -q` *(fails: Connection refused while trying to reach the API)*

------
https://chatgpt.com/codex/tasks/task_e_687bbf25ce5c8330b332895a89f694cf