### PR TITLE
Adjust create endpoints for proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ This populates helper tables like `daily_sales` in the OLAP database.
 
 ## API Endpoints
 
-* `POST /orders`: Place an order (latte not included)
-* `POST /products`: Add a new drink or snack
-* `POST /customers`: Register your most loyal caffeine addict
+* `POST /orders/new`: Place an order (latte not included)
+* `POST /products/new`: Add a new drink or snack
+* `POST /customers/new`: Register your most loyal caffeine addict
 
 Each order automatically gets logged into the CDC table, because data is sacred.
 

--- a/backend-api/customer-api/main.py
+++ b/backend-api/customer-api/main.py
@@ -20,7 +20,7 @@ class Customer(BaseModel):
     email: str
 
 
-@app.post("/customers")
+@app.post("/customers/new")
 def create_customer(customer: Customer):
     with engine.begin() as conn:
         result = conn.execute(

--- a/backend-api/order-api/main.py
+++ b/backend-api/order-api/main.py
@@ -27,7 +27,7 @@ class Order(BaseModel):
     items: list[OrderItem]
 
 
-@app.post("/orders")
+@app.post("/orders/new")
 def create_order(order: Order):
     with engine.begin() as conn:
         result = conn.execute(

--- a/backend-api/product-api/main.py
+++ b/backend-api/product-api/main.py
@@ -19,7 +19,7 @@ class Product(BaseModel):
     name: str
     price: float
 
-@app.post("/products")
+@app.post("/products/new")
 def create_product(product: Product):
     with engine.begin() as conn:
         result = conn.execute(

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -31,15 +31,15 @@ http {
         proxy_redirect off;
 
         location /orders/ {
-            proxy_pass http://order_api/;
+            proxy_pass http://order_api;
         }
 
         location /products/ {
-            proxy_pass http://product_api/;
+            proxy_pass http://product_api;
         }
 
         location /customers/ {
-            proxy_pass http://customer_api/;
+            proxy_pass http://customer_api;
         }
     }
 }

--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -87,7 +87,7 @@ export function setup() {
     if (usedEmails.has(payload.email)) {
       continue;
     }
-    const res = http.post(`${apiUrl}/customers`, JSON.stringify(payload), { headers });
+    const res = http.post(`${apiUrl}/customers/new`, JSON.stringify(payload), { headers });
     if (res.status === 200) {
       customerIds.push(res.json('id'));
       usedEmails.add(payload.email);
@@ -101,7 +101,7 @@ export function setup() {
     if (usedProductNames.has(payload.name)) {
       continue;
     }
-    const res = http.post(`${apiUrl}/products`, JSON.stringify(payload), { headers });
+    const res = http.post(`${apiUrl}/products/new`, JSON.stringify(payload), { headers });
     if (res.status === 200) {
       productIds.push(res.json('id'));
       usedProductNames.add(payload.name);
@@ -116,14 +116,14 @@ export default function (data) {
   const headers = { 'Content-Type': 'application/json' };
 
   if (Math.random() < 0.05) {
-    const res = http.post(`${apiUrl}/customers`, JSON.stringify(generateCustomer()), { headers });
+    const res = http.post(`${apiUrl}/customers/new`, JSON.stringify(generateCustomer()), { headers });
     if (res.status === 200) {
       data.customerIds.push(res.json('id'));
     }
   }
 
   if (Math.random() < 0.05) {
-    const res = http.post(`${apiUrl}/products`, JSON.stringify(generateProduct()), { headers });
+    const res = http.post(`${apiUrl}/products/new`, JSON.stringify(generateProduct()), { headers });
     if (res.status === 200) {
       data.productIds.push(res.json('id'));
     }
@@ -139,7 +139,7 @@ export default function (data) {
   }
 
   const payload = JSON.stringify({ customer_id: customerId, items });
-  const res = http.post(`${apiUrl}/orders`, payload, { headers });
+  const res = http.post(`${apiUrl}/orders/new`, payload, { headers });
 
   const success = check(res, {
     'status is 200': (r) => r.status === 200,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from . import config
 @pytest.fixture
 def test_product():
     payload = {"name": f"Test Product {uuid.uuid4().hex[:8]}", "price": 3.5}
-    resp = requests.post(f"{config.API_URL}/products", json=payload)
+    resp = requests.post(f"{config.API_URL}/products/new", json=payload)
     assert resp.status_code == 200, f"Product creation failed: {resp.text}"
     return resp.json()
 
@@ -21,7 +21,7 @@ def test_customer():
         "name": "PyTest User",
         "email": f"pytest_{int(time.time()*1000)}@example.com",
     }
-    resp = requests.post(f"{config.API_URL}/customers", json=payload)
+    resp = requests.post(f"{config.API_URL}/customers/new", json=payload)
     assert resp.status_code == 200, f"Customer creation failed: {resp.text}"
     return resp.json()
 
@@ -32,6 +32,6 @@ def test_order(test_product, test_customer):
         "customer_id": test_customer["id"],
         "items": [{"product_id": test_product["id"], "quantity": 1}],
     }
-    resp = requests.post(f"{config.API_URL}/orders", json=payload)
+    resp = requests.post(f"{config.API_URL}/orders/new", json=payload)
     assert resp.status_code == 200, f"Order creation failed: {resp.text}"
     return resp.json()["order_id"]


### PR DESCRIPTION
## Summary
- use `/customers/new`, `/orders/new`, and `/products/new`
- adapt k6 load tests, tests, and README to new endpoints
- update nginx proxy rules to keep full path

## Testing
- `pytest -q` *(fails: DB_USER, DB_PASSWORD, OLTP_DB and OLAP_DB must be provided in the .env file)*

------
https://chatgpt.com/codex/tasks/task_e_687c4b7c03548330802304e3061e1cd8