### PR TITLE
Fix k6 loadtest default host

### DIFF
--- a/k6-loadtest/loadtest.js
+++ b/k6-loadtest/loadtest.js
@@ -77,7 +77,7 @@ function generateCustomer() {
 }
 
 export function setup() {
-  const apiUrl = __ENV.API_URL || 'http://localhost:8000';
+  const apiUrl = __ENV.API_URL || 'http://gateway';
   const headers = { 'Content-Type': 'application/json' };
 
   const customerIds = [];
@@ -112,7 +112,7 @@ export function setup() {
 }
 
 export default function (data) {
-  const apiUrl = __ENV.API_URL || 'http://localhost:8000';
+  const apiUrl = __ENV.API_URL || 'http://gateway';
   const headers = { 'Content-Type': 'application/json' };
 
   if (Math.random() < 0.05) {


### PR DESCRIPTION
## Summary
- update k6 default `API_URL` to use the gateway hostname

## Testing
- `pytest tests/test_create_order.py::test_create_order -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_687c4cdc578c8330bf3bbfaa0870b506