### PR TITLE
Fix Nginx path handling

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -31,15 +31,15 @@ http {
         proxy_redirect off;
 
         location /orders/ {
-            proxy_pass http://order_api;
+            proxy_pass http://order_api/;
         }
 
         location /products/ {
-            proxy_pass http://product_api;
+            proxy_pass http://product_api/;
         }
 
         location /customers/ {
-            proxy_pass http://customer_api;
+            proxy_pass http://customer_api/;
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure gateway preserves backend paths when forwarding

## Testing
- `pytest -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_687c4e28d22c8330907dbe8c87c0d134