### PR TITLE
Fix nginx path rewriting for k6 load test

### DIFF
--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -31,15 +31,15 @@ http {
         proxy_redirect off;
 
         location /orders/ {
-            proxy_pass http://order_api/;
+            proxy_pass http://order_api;
         }
 
         location /products/ {
-            proxy_pass http://product_api/;
+            proxy_pass http://product_api;
         }
 
         location /customers/ {
-            proxy_pass http://customer_api/;
+            proxy_pass http://customer_api;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix proxy_pass paths in the gateway nginx config so FastAPI endpoints receive the correct prefixes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c4f66240c8330806fef3cf5a34ec8