### PR TITLE
Fix dbt profiles.yml parsing error

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -6,7 +6,7 @@ oltp:
       host: "{{ env_var('OLTP_HOST', 'oltp-db') }}"
       user: "{{ env_var('DB_USER') }}"
       password: "{{ env_var('DB_PASSWORD') }}"
-      port: {{ env_var('OLTP_PORT', 5432) }}
+      port: "{{ env_var('OLTP_PORT', 5432) }}"
       dbname: "{{ env_var('OLTP_DB') }}"
       schema: public
 
@@ -18,6 +18,6 @@ olap:
       host: "{{ env_var('OLAP_HOST', 'olap-db') }}"
       user: "{{ env_var('DB_USER') }}"
       password: "{{ env_var('DB_PASSWORD') }}"
-      port: {{ env_var('OLAP_PORT', 5432) }}
+      port: "{{ env_var('OLAP_PORT', 5432) }}"
       dbname: "{{ env_var('OLAP_DB') }}"
       schema: public


### PR DESCRIPTION
## Summary
- escape env vars for port numbers in `dbt/profiles.yml`

## Testing
- `pytest -q` *(fails: ConnectionError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c56897a348330adfaefaf247ae2e7