### PR TITLE
Fix dbt seed schema duplication

### DIFF
--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -6,6 +6,5 @@ profile: brewlytics
 
 seeds:
   brewlytics_dbt:
-    +schema: public
     +quote_columns: false
 


### PR DESCRIPTION
## Summary
- remove the redundant `+schema` override from `dbt_project.yml`

## Testing
- `pip install requests python-dotenv psycopg2-binary sqlalchemy fastapi uvicorn`
- `pytest -q` *(fails: ConnectionError: HTTPConnectionPool(host='localhost', port=8000))*

------
https://chatgpt.com/codex/tasks/task_e_687c583bb5f4833094beb6eb02883f76