### PR TITLE
Disable k6 service by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ cp .env.sample .env
 docker-compose up --build
 ```
 All Postgres containers (oltp-db, olap-db and metabase-db) store their data in named volumes, so your databases survive `docker-compose down`.
+The `k6` load-testing container is disabled by default using a Compose profile, so it won't start automatically.
 
 * API Gateway: `http://localhost:8000`
 * Airflow: `http://localhost:8080`
@@ -156,7 +157,7 @@ To trigger the DAG manually, open [Airflow](http://localhost:8080) and log in wi
 Want to simulate the morning rush?
 
 ```bash
-docker-compose run k6
+docker-compose --profile k6 run k6
 ```
 
 K6 will bombard your API like a line of customers 2 minutes before closing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,8 @@ services:
 
   k6:
     image: grafana/k6
+    profiles:
+      - k6
     volumes:
       - ./k6-loadtest:/scripts
     entrypoint: "k6 run /scripts/loadtest.js"


### PR DESCRIPTION
## Summary
- keep `k6` service behind a compose profile
- document that the k6 container is disabled by default
- update how to manually run the k6 load test

## Testing
- `pip install requests pytest`
- `pip install python-dotenv`
- `pip install psycopg2-binary`
- `pytest -q` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a1c778483309c35c4759b23a08f