### PR TITLE
Fix DAG error by updating CDC triggers

### DIFF
--- a/flyway/migrations/oltp/V5__cdc_triggers_product_id.sql
+++ b/flyway/migrations/oltp/V5__cdc_triggers_product_id.sql
@@ -1,0 +1,38 @@
+-- Ensure CDC entries always contain product_id by logging only from order_items
+
+-- remove old trigger and function for orders table
+DROP TRIGGER IF EXISTS trg_order_cdc ON orders;
+DROP FUNCTION IF EXISTS log_order_cdc();
+
+-- order_items trigger already captures product info; ensure table_name is 'orders'
+CREATE OR REPLACE FUNCTION log_order_item_cdc() RETURNS TRIGGER AS $$
+DECLARE
+    ord orders%ROWTYPE;
+    rec RECORD;
+    data JSONB;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        rec := OLD;
+    ELSE
+        rec := NEW;
+    END IF;
+    SELECT * INTO ord FROM orders WHERE id = rec.order_id;
+    data := jsonb_build_object(
+        'order_id', ord.id,
+        'customer_id', ord.customer_id,
+        'employee_id', ord.employee_id,
+        'order_time', ord.order_time,
+        'product_id', rec.product_id,
+        'quantity', rec.quantity,
+        'price', rec.price
+    );
+    INSERT INTO cdc_orders(payload, op, table_name)
+    VALUES (data, TG_OP, 'orders');
+    RETURN rec;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_order_item_cdc ON order_items;
+CREATE TRIGGER trg_order_item_cdc
+AFTER INSERT OR UPDATE OR DELETE ON order_items
+FOR EACH ROW EXECUTE PROCEDURE log_order_item_cdc();


### PR DESCRIPTION
## Summary
- revert DAG workaround for missing product data
- update CDC triggers to log product information from `order_items`

## Testing
- `pytest -q` *(fails: RuntimeError about missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_687c6c7bf6a883308c4b718a360c5182