### PR TITLE
Add profiles for tests and Metabase setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,7 @@ OLTP_DB=coffee_oltp
 OLAP_DB=coffee_olap
 MB_DB=metabase
 AIRFLOW_DB=airflow
+METABASE_USER=admin@example.com
+METABASE_PASSWORD=metabase123
+AIRFLOW_USER=admin
+AIRFLOW_PASSWORD=admin

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ erDiagram
 git clone https://github.com/babanomania/brewlytics.git
 cd brewlytics
 cp .env.sample .env
-# Review and adjust values in `.env` if needed
+# Review and adjust values in `.env` if needed. It now contains credentials for
+# Metabase and Airflow users that are used during setup.
 ```
 
 ### Start the System
@@ -150,7 +151,8 @@ Each order automatically gets logged into the CDC table, because data is sacred.
 * Runs every 5 minutes, just like a properly tuned espresso machine
 
 To trigger the DAG manually, open [Airflow](http://localhost:8080) and log in with
-`admin` / `admin`. Click the play button next to `cdc_to_star`.
+the credentials from `.env` (`AIRFLOW_USER` / `AIRFLOW_PASSWORD`). Click the play
+button next to `cdc_to_star`.
 
 ## Load Testing with K6
 
@@ -172,21 +174,22 @@ Connect Metabase to the OLAP PostgreSQL database.
 2. Add a new PostgreSQL database using host `olap-db`, port `5432`, user `brew`,
    password `brew`, and database `coffee_olap`.
 3. (Optional) customise `metabase/dashboard.json` and run
-   `python metabase/setup_dashboards.py` to create an example dashboard
-   automatically. The script reads the config file path from the
-   `DASHBOARD_CONFIG` environment variable (defaults to `metabase/dashboard.json`).
+   `docker-compose --profile metabase run --rm metabase-setup` to create an
+   example dashboard automatically. The script reads the config file path from
+   the `DASHBOARD_CONFIG` environment variable (defaults to
+   `metabase/dashboard.json`).
 
-You can also customise the dashboard by providing a JSON config file and
-running `python metabase/setup_dashboards.py`. The script reads the file
-path from the `DASHBOARD_CONFIG` environment variable (defaults to
+You can also customise the dashboard by providing a JSON config file and running
+`docker-compose --profile metabase run --rm metabase-setup`. The script reads
+the file path from the `DASHBOARD_CONFIG` environment variable (defaults to
 `metabase/dashboard.json`).
 
 ## Running Tests
 
-Make sure the stack is running (`docker-compose up`). In another terminal, run:
+Spin up the stack and run the tests using the dedicated profile:
 
 ```bash
-pytest tests/
+docker-compose --profile tests run --rm pytest
 ```
 
 This test suite verifies that an order flows from the API through Airflow into the OLAP database.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,8 @@ services:
     volumes:
       - ./airflow-pipeline/dags:/opt/airflow/dags
       - airflow-data:/opt/airflow
-    entrypoint: bash -c "airflow db init && airflow users create --username admin --password admin --firstname admin --lastname admin --role Admin --email admin@example.com"
+    entrypoint: >
+      bash -c "airflow db init && airflow users create --username $${AIRFLOW_USER} --password $${AIRFLOW_PASSWORD} --firstname admin --lastname admin --role Admin --email admin@example.com"
     depends_on:
       - airflow-db
 
@@ -202,6 +203,8 @@ services:
 
   metabase-db:
     image: postgres:14
+    profiles:
+      - metabase
     env_file: .env
     environment:
       POSTGRES_USER: ${DB_USER}
@@ -220,6 +223,8 @@ services:
 
   metabase:
     image: metabase/metabase
+    profiles:
+      - metabase
     env_file: .env
     environment:
       MB_DB_TYPE: postgres
@@ -236,6 +241,21 @@ services:
       - flyway-olap
       - metabase-db
 
+  metabase-setup:
+    image: python:3.11
+    profiles:
+      - metabase
+    env_file: .env
+    environment:
+      METABASE_HOST: http://metabase:3000
+    volumes:
+      - ./metabase:/metabase
+    working_dir: /metabase
+    entrypoint: bash -c "pip install -r requirements.txt && python setup_dashboards.py"
+    depends_on:
+      metabase:
+        condition: service_started
+
   k6:
     image: grafana/k6
     profiles:
@@ -250,6 +270,31 @@ services:
         condition: service_healthy
       olap-db:
         condition: service_healthy
+
+  pytest:
+    image: python:3.11
+    profiles:
+      - tests
+    env_file: .env
+    environment:
+      API_URL: http://gateway
+      OLTP_HOST: oltp-db
+      OLTP_PORT: 5432
+      OLAP_HOST: olap-db
+      OLAP_PORT: 5433
+    volumes:
+      - ./tests:/tests
+    working_dir: /tests
+    entrypoint: bash -c "pip install -r requirements.txt && pytest -vv"
+    depends_on:
+      gateway:
+        condition: service_started
+      oltp-db:
+        condition: service_healthy
+      olap-db:
+        condition: service_healthy
+      airflow:
+        condition: service_started
 
 volumes:
   oltp-data:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+requests
+psycopg2-binary
+python-dotenv


### PR DESCRIPTION
## Summary
- add Metabase and Airflow credentials to `.env.sample`
- parameterize Airflow user creation via environment variables
- add Metabase services behind a profile and add a dashboard setup helper
- add pytest service with its own profile and requirements
- document how to run tests and dashboards with Compose profiles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687c77477840833094f15fe792c65e18