### PR TITLE
Sync test payloads with k6 generator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import time
 import uuid
+import random
 
 import pytest
 import requests
@@ -7,9 +8,29 @@ import requests
 from . import config
 
 
+def _generate_product():
+    product_base_names = [
+        "Espresso",
+        "Latte",
+        "Cappuccino",
+        "Flat White",
+        "Mocha",
+        "Cold Brew",
+        "Chai Latte",
+        "Americano",
+        "Cortado",
+        "Macchiato",
+    ]
+    product_sizes = ["Small", "Medium", "Large"]
+    size = random.choice(product_sizes)
+    base = random.choice(product_base_names)
+    price = round(random.uniform(2, 7), 2)
+    return {"name": f"{size} {base}", "price": price}
+
+
 @pytest.fixture
 def test_product():
-    payload = {"name": f"Test Product {uuid.uuid4().hex[:8]}", "price": 3.5}
+    payload = _generate_product()
     resp = requests.post(f"{config.API_URL}/products/new", json=payload)
     assert resp.status_code == 200, f"Product creation failed: {resp.text}"
     return resp.json()
@@ -22,12 +43,42 @@ def active_employee_id():
     return resp.json()[0]["id"]
 
 
+def _generate_customer():
+    first_names = [
+        "Alice",
+        "Bob",
+        "Priya",
+        "John",
+        "Maria",
+        "Wei",
+        "Ahmed",
+        "Olivia",
+        "Carlos",
+        "Nina",
+    ]
+    last_names = [
+        "Smith",
+        "Patel",
+        "Garcia",
+        "Jones",
+        "Khan",
+        "Kim",
+        "Chen",
+        "Brown",
+        "Singh",
+        "Davis",
+    ]
+    first = random.choice(first_names)
+    last = random.choice(last_names)
+    return {
+        "name": f"{first} {last}",
+        "email": f"{first.lower()}.{last.lower()}_{int(time.time()*1000)}@example.com",
+    }
+
+
 @pytest.fixture
 def test_customer():
-    payload = {
-        "name": "PyTest User",
-        "email": f"pytest_{int(time.time()*1000)}@example.com",
-    }
+    payload = _generate_customer()
     resp = requests.post(f"{config.API_URL}/customers/new", json=payload)
     assert resp.status_code == 200, f"Customer creation failed: {resp.text}"
     return resp.json()
@@ -38,7 +89,12 @@ def test_order(test_product, test_customer, active_employee_id):
     payload = {
         "customer_id": test_customer["id"],
         "employee_id": active_employee_id,
-        "items": [{"product_id": test_product["id"], "quantity": 1}],
+        "items": [
+            {
+                "product_id": test_product["id"],
+                "quantity": random.randint(1, 5),
+            }
+        ],
     }
     resp = requests.post(f"{config.API_URL}/orders/new", json=payload)
     assert resp.status_code == 200, f"Order creation failed: {resp.text}"


### PR DESCRIPTION
## Summary
- randomize pytest test data to mirror k6 loadtest setup

## Testing
- `pytest -k test_create_order -vv` *(fails: DNS resolution failure)*

------
https://chatgpt.com/codex/tasks/task_e_687c7c3dbe748330bd6839b1fcf17c59