### PR TITLE
Fix Metabase card creation

### DIFF
--- a/metabase/setup_dashboards.py
+++ b/metabase/setup_dashboards.py
@@ -52,8 +52,13 @@ def create_dashboard(session: requests.Session, host: str, name: str) -> int:
 def create_card(session: requests.Session, host: str, db_id: int, card: Dict[str, Any]) -> int:
     payload = {
         "name": card["name"],
-        "dataset_query": {"database": db_id, "native": {"query": card["query"]}},
+        "dataset_query": {
+            "database": db_id,
+            "native": {"query": card["query"], "template-tags": {}},
+            "type": "native",
+        },
         "display": "table",
+        "visualization_settings": {},
     }
     resp = session.post(f"{host}/api/card", json=payload)
     try:


### PR DESCRIPTION
## Summary
- include required dataset fields when creating Metabase cards

## Testing
- `docker-compose --profile tests run --rm pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c941ae11883309a2562734a3d4c9a